### PR TITLE
update

### DIFF
--- a/src/Slugger.php
+++ b/src/Slugger.php
@@ -20,6 +20,7 @@ use craft\services\Plugins;
 use craft\events\PluginEvent;
 use craft\services\Elements;
 use craft\web\twig\variables\CraftVariable;
+use craft\helpers\ElementHelper;
 
 use yii\base\Event;
 
@@ -85,9 +86,9 @@ class Slugger extends Plugin
         );
         
        Event::on(Elements::class, Elements::EVENT_AFTER_SAVE_ELEMENT, function(Event $event){
-        
+
             // Only hash if element is entry and new entry
-            if ( ($event->element instanceof \craft\elements\Entry) && $event->isNew )
+            if ( ($event->element instanceof \craft\elements\Entry) && $event->isNew && !ElementHelper::isDraftOrRevision($event->element) )
             {
             
                 // Get the settings


### PR DESCRIPTION
Hi, discovered that the plugin needs to also consider the Draft or Revision status of an entry to truly detect whether it's new. Without considering this, it always creates a new slug on every save (not just when it's a new entry).